### PR TITLE
Fixes entrypoint in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM scratch
 
 COPY server .
 
-CMD ["/server"]
+ENTRYPOINT ["/server"]


### PR DESCRIPTION
The standard entrypoint uses `/bin/sh` which is not in the image.