### PR TITLE
Fixes Go build environment.

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -36,7 +36,7 @@ jobs:
         echo github.head_ref: ${{ github.head_ref }}
         echo github.base_ref: ${{ github.base_reg }}
     - name: Build binary
-      run: GOOS=linux GOARCH=amd64 CGOENABLED=0 go build -o server ./main.go
+      run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o server ./main.go
     - name: Docker build and push
       uses: docker/build-push-action@v1.1.1
       with:


### PR DESCRIPTION
Fixes incorrect Go environment variable name. Without it, Go will not build a statically linked image, which will cause a 'from scratch' Docker image to break. 