### PR TITLE
Removes extra release triggers from GitHub action.

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -8,9 +8,7 @@ on:
     - master
   release:
     types:
-    - created
     - published
-    - released
 
 env:
   DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}


### PR DESCRIPTION
The act of publishing a release currently triggers three builds. This PR modifies the configuration to build only once.