### PR TITLE
Splits CI and release workflows.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+name: Build code
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Build binary
+      run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o server ./main.go
+    - name: Lint
+      uses: golangci/golangci-lint-action@v4
+      with:
+        skip-pkg-cache: false
+        skip-build-cache: false
+        args: --timeout=180s

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,5 @@
-name: CI Workflow
+name: Publish artifacts
 on:
-  push:
-    branches:
-    - master
-  pull_request:
-    branches:
-    - master
   release:
     types:
     - published
@@ -22,16 +16,12 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-    - name: Dump variables
-      run: |
-        echo github.event_name: ${{ github.event_name }}
-        echo github.event.release.tag_name: ${{ github.event.release.tag_name }}
-        echo github.ref: ${{ github.ref }}
-        echo github.sha: ${{ github.sha }}
-        echo github.head_ref: ${{ github.head_ref }}
-        echo github.base_ref: ${{ github.base_reg }}
     - name: Build binary
       run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o server ./main.go
+    - name: Lint
+      uses: golangci/golangci-lint-action@v4
+      with:
+        args: --timeout=180s
     - name: Docker login
       uses: docker/login-action@v3
       with:
@@ -43,4 +33,4 @@ jobs:
       with:
         context: .
         tags: ${{ vars.DOCKER_REGISTRY }}/${{ vars.DOCKER_REPO }}:${{ github.event_name == 'release' && github.event.release.tag_name || format('master-{0}', github.sha) }}
-        push: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
+        push: true

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -68,7 +68,10 @@ func startServer(cmd *cobra.Command, args []string) error {
 	metricsScraper := server.New(metricsClient, port, endpointPath)
 	go func() {
 		<-stopChan
-		metricsScraper.Shutdown(context.Background())
+		err := metricsScraper.Shutdown(context.Background())
+		if err != nil && err != http.ErrServerClosed {
+			logrus.WithError(err).Error("Error shutting down the server")
+		}
 	}()
 	logrus.WithField("address", metricsScraper.Addr).Info("Launching server")
 	err = metricsScraper.ListenAndServe()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -50,7 +50,7 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 		logrus.
 			WithError(err).
 			WithField("body", string(body)).
-			Error("error polling API server")
+			Error("Error polling API server")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Workflows for Dependabot initiated builds now cannot access repository secrets. The CI workflow does not need access to the Docker secrets, so this PR splits the CI and the release workflows, allowing CI workflows to pass.