### PR TITLE
Disables package caching in lint.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,6 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v4
       with:
-        skip-pkg-cache: false
-        skip-build-cache: false
+        skip-pkg-cache: true
+        skip-build-cache: true
         args: --timeout=180s

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,8 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v4
       with:
+        skip-pkg-cache: true
+        skip-build-cache: true
         args: --timeout=180s
     - name: Docker login
       uses: docker/login-action@v3


### PR DESCRIPTION
This PR disables package and build caching in the lint action as that can break the builds.